### PR TITLE
Fix post deletion to remove entity

### DIFF
--- a/src/main/java/org/example/restfulblogflatform/service/post/PostServiceImpl.java
+++ b/src/main/java/org/example/restfulblogflatform/service/post/PostServiceImpl.java
@@ -100,7 +100,7 @@ public class PostServiceImpl implements PostService {
     public void delete(Long postId) {
         Post post = postValidator.getOrThrow(postId);
         post.getUser().removePost(post); // 연관관계 해제
-        // 실제로는 postRepository.delete(post) 등을 통해 DB에서 제거
+        postRepository.delete(post);
         // 필요한 경우, 첨부파일도 함께 제거(물리 파일 삭제) 로직을 구현해야 합니다.
     }
 


### PR DESCRIPTION
## Summary
- delete posts through the repository instead of leaving them attached after removing relationships

## Testing
- Not run (Gradle wrapper download blocked by proxy)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693a7ea5d4e88332b999bd9ffb6b5678)